### PR TITLE
Optional architecture validation

### DIFF
--- a/pyausaxs/config.py
+++ b/pyausaxs/config.py
@@ -1,0 +1,1 @@
+architecture_runtime_validation = True

--- a/pyausaxs/integration.py
+++ b/pyausaxs/integration.py
@@ -2,6 +2,7 @@ import multiprocessing
 import ctypes as ct
 from enum import Enum
 
+from pyausaxs.config import architecture_runtime_validation
 from pyausaxs.loader import find_lib_path
 from pyausaxs.architecture import CPUFeatures
 
@@ -22,7 +23,7 @@ class AUSAXSLIB:
 
     def _check_cpu_compatibility(self):
         """Check if the current CPU is compatible with the AUSAXS library."""
-        if not CPUFeatures.is_compatible_architecture():
+        if architecture_runtime_validation and not CPUFeatures.is_compatible_architecture():
             self.state = self.STATE.FAILED
             raise RuntimeError(f"AUSAXS: Incompatible CPU architecture: {CPUFeatures.get_architecture()}")
         return True


### PR DESCRIPTION
This PR adds a new config file containing a single flag: `architecture_runtime_validation`. The idea is that this file is easily patched by the Debian fork to completely disable this runtime validation check, as there is no reason to verify compatibility since it is enforced by the distribution itself. Having the flag in a separate file makes a patch easy to maintain. 